### PR TITLE
Fix kiosk link and add dashboard button

### DIFF
--- a/app.py
+++ b/app.py
@@ -536,6 +536,7 @@ def api_notifications():
 
 
 @app.route('/kiosk')
+@app.route('/kiosk/')
 def kiosk_page():
     """Public kiosk interface for placing orders."""
     return render_template('kiosk.html', user=None, username='Guest')

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -339,6 +339,17 @@ input:checked + .slider:before {
     border-radius: 4px;
     text-decoration: none;
 }
+
+/* Generic kiosk link/button styling */
+.kiosk-link {
+    display: inline-block;
+    background-color: #6c757d;
+    color: #fff;
+    text-align: center;
+    padding: 6px 12px;
+    border-radius: 4px;
+    text-decoration: none;
+}
 .error {
     color: red;
 }

--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -8,10 +8,12 @@
         <li class="{% if request.path.startswith('/wm/ldapserver') %}active{% endif %}"><a href="/wm/ldapserver">LDAP Server</a></li>
         <li>Licensing</li>
         <li>HPC</li>
+        <li class="{% if request.path.startswith('/kiosk') %}active{% endif %}"><a href="{{ url_for('kiosk_page') }}">Kiosk</a></li>
     {% else %}
         <li class="{% if request.path.startswith('/notification_email') %}active{% endif %}"><a href="/notification_email">Notification Email</a></li>
         <li class="{% if request.path.startswith('/models') %}active{% endif %}"><a href="/models">Models</a></li>
         <li class="{% if request.path.startswith('/input_files') %}active{% endif %}"><a href="/input_files">Input Files</a></li>
         <li class="{% if request.path.startswith('/scheduling') %}active{% endif %}"><a href="/scheduling">Scheduling</a></li>
+        <li class="{% if request.path.startswith('/kiosk') %}active{% endif %}"><a href="{{ url_for('kiosk_page') }}">Kiosk</a></li>
     {% endif %}
 </ul>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -5,6 +5,7 @@
     <h1>Hello! {{ user.name }}</h1>
     <p class="subtitle">Welcome to R3S Workflow Manager</p>
     <p class="subtitle">Role: {{ user.role }} | Group: {{ user.group_name }}</p>
+    <a href="{{ url_for('kiosk_page') }}" class="kiosk-link">Open Kiosk</a>
 </section>
 <section class="dashboard-body">
     <div class="notifications">


### PR DESCRIPTION
## Summary
- handle `/kiosk/` URL as well as `/kiosk`
- add links to the kiosk in sidebar
- show a kiosk button on the dashboard
- add generic kiosk link styling

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6883201d56948325ba36c7cfeb075992